### PR TITLE
Enable connection timeout in TwsConnectionController

### DIFF
--- a/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsConnectionController.cs
+++ b/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsConnectionController.cs
@@ -133,11 +133,11 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
             }
 
             // Set the operation to cancel after 5 seconds
-            ////CancellationTokenSource tokenSource = new CancellationTokenSource(10000);
-            ////tokenSource.Token.Register(() =>
-            ////{
-            ////    taskSource.SetCanceled();
-            ////});
+            CancellationTokenSource tokenSource = new CancellationTokenSource(5000);
+            tokenSource.Token.Register(() =>
+            {
+               taskSource.TrySetCanceled();
+            });
 
             this.twsCallbackHandler.ConnectionAcknowledgementEvent += ConnectionAcknowledgementCallback;
             this.clientSocket.Connect(this.host, this.port, this.clientId);


### PR DESCRIPTION
For our use case, I've created a background job that periodically calls `await connectionController.EnsureConnectedAsync()` and broadcasts a heartbeat to SignalR clients. However, the background job is hanging forever if Trader Workstation isn't open. It might be beneficial to enable the timeout to allow consumers to handle underlying connection issues. Thoughts?