### PR TITLE
Add more information to the error TwsException

### DIFF
--- a/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsControllerBase.cs
+++ b/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsControllerBase.cs
@@ -229,7 +229,7 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                     this.twsCallbackHandler.ContractDetailsEvent -= contractDetailsEventHandler;
                     this.twsCallbackHandler.ContractDetailsEndEvent -= contractDetailsEndEventHandler;
                     this.twsCallbackHandler.ErrorEvent -= errorEventHandler;
-                    taskSource.TrySetException(new TwsException(args.ErrorMessage));
+                    taskSource.TrySetException(new TwsException(args));
                 }
             };
 
@@ -375,7 +375,7 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                     this.twsCallbackHandler.HistoricalDataEvent -= historicalDataEventHandler;
                     this.twsCallbackHandler.HistoricalDataEndEvent -= historicalDataEndEventHandler;
                     this.twsCallbackHandler.ErrorEvent -= errorEventHandler;
-                    taskSource.TrySetException(new TwsException(args.ErrorMessage));
+                    taskSource.TrySetException(new TwsException(args));
                 }
             };
 
@@ -604,7 +604,7 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                     eventArgs.ErrorCode == TwsErrorCodes.OrderCannotBeCancelled2)
                 {
                     this.twsCallbackHandler.ErrorEvent -= errorEventCallback;
-                    taskSource.TrySetException(new TwsException($"Order {eventArgs.Id} cannot be canceled"));
+                    taskSource.TrySetException(new TwsException($"Order {eventArgs.Id} cannot be canceled", eventArgs.ErrorCode, eventArgs.Id));
                 }
             };
 
@@ -990,7 +990,7 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                     this.twsCallbackHandler.TickSnapshotEndEvent -= tickSnapshotEndEventHandler;
                     this.twsCallbackHandler.TickEFPEvent -= tickEFPEventHandler;
                     this.twsCallbackHandler.ErrorEvent -= errorEventHandler;
-                    taskSource.TrySetException(new TwsException(args.ErrorMessage));
+                    taskSource.TrySetException(new TwsException(args));
                 }
             };
 
@@ -1085,7 +1085,7 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                     // The error is associated with this request
                     this.twsCallbackHandler.RealtimeBarEvent -= realtimeBarEventHandler;
                     this.twsCallbackHandler.ErrorEvent -= errorEventHandler;
-                    taskSource.TrySetException(new TwsException(args.ErrorMessage));
+                    taskSource.TrySetException(new TwsException(args));
                 }
             };
 

--- a/AutoFinance.Broker/InteractiveBrokers/Exceptions/TwsException.cs
+++ b/AutoFinance.Broker/InteractiveBrokers/Exceptions/TwsException.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed under the Apache License, Version 2.0.
 
+using AutoFinance.Broker.InteractiveBrokers.EventArgs;
+
 namespace AutoFinance.Broker.InteractiveBrokers.Exceptions
 {
     using System;
@@ -17,5 +19,39 @@ namespace AutoFinance.Broker.InteractiveBrokers.Exceptions
             : base(message)
         {
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TwsException"/> class.
+        /// </summary>
+        /// <param name="message">The exception message</param>
+        /// <param name="errorCode">The TWS error code associated to this exception</param>
+        /// <param name="id">The id associated to this error.</param>
+        public TwsException(string message, int errorCode, int? id)
+            : base(message)
+        {
+            this.ErrorCode = errorCode;
+            this.Id = id;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TwsException"/> class.
+        /// </summary>
+        /// <param name="errorEventArgs">An ErrorEventArgs instance raised by TWS</param>
+        public TwsException(ErrorEventArgs errorEventArgs)
+            : base(errorEventArgs.ErrorMessage)
+        {
+            this.ErrorCode = errorEventArgs.ErrorCode;
+            this.Id = errorEventArgs.Id;
+        }
+
+        /// <summary>
+        /// Gets the error code associated to this exception
+        /// </summary>
+        public int? ErrorCode { get; }
+
+        /// <summary>
+        /// Gets the request id associated to this error.
+        /// </summary>
+        public int? Id { get; }
     }
 }


### PR DESCRIPTION
When doing error handling, it's hard to know the cause of the error since the TwsException only contains a error message.

I've added the ErrorEventArgs information to the TwsException so we can at least know the error code.

This is non-breaking as the old TwsException constructor remains and the new fields are optional.