### PR TITLE
can't request streaming market data

### DIFF
--- a/AutoFinance.Broker.IntegrationTests/InteractiveBrokers/Controllers/TwsControllerBaseTests.cs
+++ b/AutoFinance.Broker.IntegrationTests/InteractiveBrokers/Controllers/TwsControllerBaseTests.cs
@@ -691,6 +691,10 @@ namespace AutoFinance.Broker.IntegrationTests.InteractiveBrokers.Controllers
             };
 
             var marketDataResult = await twsObjectFactory.TwsControllerBase.RequestMarketDataAsync(contract, "233", false, false, null);
+            // wait up to 10 seconds for some market data
+            await Task.Delay(10 * 1000);
+            // cancel subscription for proper work of TWS API
+            twsObjectFactory.TwsControllerBase.CancelMarketData(marketDataResult.TickerId);
 
             marketDataResult.Should().NotBeNull();
             tickPriceEventArgs.Should().NotBeNull();
@@ -731,6 +735,10 @@ namespace AutoFinance.Broker.IntegrationTests.InteractiveBrokers.Controllers
             // Request delayed data feed
             twsObjectFactory.TwsControllerBase.RequestMarketDataType(3);
             var marketDataResult = await twsObjectFactory.TwsControllerBase.RequestMarketDataAsync(contract, "233", false, false, null);
+            // wait up to 10 seconds for some market data
+            await Task.Delay(10 * 1000);
+            // cancel subscription for proper work of TWS API
+            twsObjectFactory.TwsControllerBase.CancelMarketData(marketDataResult.TickerId);
 
             marketDataResult.Should().NotBeNull();
             tickPriceEventArgs.Should().NotBeNull();

--- a/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsControllerBase.cs
+++ b/AutoFinance.Broker/InteractiveBrokers/Controllers/TwsControllerBase.cs
@@ -1000,8 +1000,6 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
             CancellationTokenSource tokenSource = new CancellationTokenSource(60 * 1000);
             tokenSource.Token.Register(() =>
             {
-                this.CancelMarketData(tickerId);
-
                 this.twsCallbackHandler.TickPriceEvent -= tickPriceEventHandler;
                 this.twsCallbackHandler.TickSizeEvent -= tickSizeEventHandler;
                 this.twsCallbackHandler.TickStringEvent -= tickStringEventHandler;
@@ -1011,7 +1009,11 @@ namespace AutoFinance.Broker.InteractiveBrokers.Controllers
                 this.twsCallbackHandler.TickEFPEvent -= tickEFPEventHandler;
                 this.twsCallbackHandler.ErrorEvent -= errorEventHandler;
 
-                taskSource.TrySetCanceled();
+                // https://stackoverflow.com/questions/20830998/async-always-waitingforactivation
+                if (taskSource.Task.Status == TaskStatus.WaitingForActivation)
+                {
+                    taskSource.TrySetResult(new TickSnapshotEndEventArgs(tickerId));
+                }
             });
 
             this.twsCallbackHandler.TickPriceEvent += tickPriceEventHandler;


### PR DESCRIPTION
Changed logic of work with market data.
User have to cancel on it's own streaming market data request (snapshot=false), but can receive market ticks
as much time as he/she needs.
User may cancel snapshot market data request (snapshot=true), or wait 11 seconds while snapshot request automatically close in TWS API.